### PR TITLE
Update to Geode 5.3.0 and GD 2.2081

### DIFF
--- a/mod.json
+++ b/mod.json
@@ -1,11 +1,11 @@
 {
-    "geode": "4.8.0",
-    "version": "v1.4.4",
+    "geode": "5.3.0",
+    "version": "v1.4.5",
     "gd": {
-        "win": "2.2074",
-        "mac": "2.2074",
-        "android": "2.2074",
-        "ios": "2.2074"
+        "win": "2.2081",
+        "mac": "2.2081",
+        "android": "2.2081",
+        "ios": "2.2081"
     },
     "id": "cgytrus.menu-shaders",
     "name": "Menu Shaders",
@@ -22,18 +22,16 @@
             "resources/shaders/*.glsl"
         ]
     },
-    "dependencies": [
-        {
-            "id": "geode.node-ids",
+    "dependencies": {
+        "geode.node-ids": {
             "version": ">=v1.21.1",
             "importance": "required"
         },
-        {
-            "id": "geode.texture-loader",
+        "geode.texture-loader": {
             "version": "*",
             "importance": "recommended"
         }
-    ],
+    },
     "settings": {
         "show-main": {
             "name": "Show in main menu",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -722,10 +722,11 @@ class $modify(GJGarageLayer) {
     }
 };
 
+/*
 #include <Geode/modify/LeaderboardsLayer.hpp>
 class $modify(LeaderboardsLayer) {
-    bool init(LeaderboardState p0) {
-        if (!LeaderboardsLayer::init(p0))
+    bool init() {
+        if (!LeaderboardsLayer::init())
             return false;
         if (!ShaderNode::tryReplaceBackgroundInLayer(this, "leaderboards"))
             return true;
@@ -736,6 +737,7 @@ class $modify(LeaderboardsLayer) {
         return true;
     }
 };
+*/
 
 #include <Geode/modify/GauntletSelectLayer.hpp>
 class $modify(GauntletSelectLayer) {


### PR DESCRIPTION
## Changes
- Updated Geode version from 4.8.0 to 5.3.0
- Updated Geometry Dash version from 2.2074 to 2.2081
- Updated dependencies format for Geode 5.x compatibility
- Commented out LeaderboardsLayer modification to fix compatibility issues, not sure if that will bite me back in the ass

## Reason
Mod now works with the latest Geode and GD versions. I got a bit impatient whoops.